### PR TITLE
chore: post release cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,9 +266,7 @@ jobs:
           name: "[helm-chart] package"
 
       - name: Test
-        # Workaround until we have a release
-        # run: nix develop --impure .#ci -c make test-e2e
-        run: nix develop --impure .#ci -c make test-e2e-local
+        run: nix develop --impure .#ci -c make test-e2e
         env:
           KIND_K8S_VERSION: ${{ matrix.k8s_version }}
           LOAD_IMAGE_ARCHIVE: ${{ github.workspace }}/docker.tar

--- a/.yamlignore
+++ b/.yamlignore
@@ -1,3 +1,4 @@
 /deploy/
 /e2e/deploy/
 /e2e/test/
+/.github/

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -4,3 +4,4 @@ extends: default
 
 rules:
   line-length: disable
+  document-start: disable

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -43,9 +43,7 @@ import (
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
 
-const (
-	defaultTimeout = 2 * time.Minute
-)
+const defaultTimeout = 2 * time.Minute
 
 var testenv env.Environment
 
@@ -113,13 +111,13 @@ func TestMain(m *testing.M) {
 
 		// Unsealing and Vault access only works in the default namespace at the moment
 		testenv.Setup(useNamespace("default"))
-
-		testenv.Setup(installVault, waitForVaultTLS)
-		testenv.Finish(uninstallVault)
 	} else {
 		// Unsealing and Vault access only works in the default namespace at the moment
 		testenv.Setup(useNamespace("default"))
 	}
+
+	testenv.Setup(installVault, waitForVaultTLS)
+	testenv.Finish(uninstallVault)
 
 	os.Exit(testenv.Run(m))
 }

--- a/garden.yaml
+++ b/garden.yaml
@@ -8,36 +8,23 @@ spec:
     version: "1.22.2"
 
 ---
-kind: Deploy
-type: kubernetes
-name: vault
-dependencies:
-  - deploy.vault-operator
-spec:
-  namespace: default
-  files:
-    - ./e2e/deploy/vault/rbac.yaml
-    - ./e2e/deploy/vault/vault.yaml
-
----
 kind: Build
 type: container
-name: secrets-webhook
+name: secrets-webhook-image
 exclude:
   - .direnv/**/*
   - .devenv/**/*
   - build/**/*
   - e2e/**/*
+  - examples/**/*
 
 ---
 kind: Deploy
 type: helm
 name: secrets-webhook
 dependencies:
-  - deploy.vault
-variables:
-  repository: ${actions.build.secrets-webhook.outputs.deployment-image-name}
-  tag: ${actions.build.secrets-webhook.version}
+  - build.secrets-webhook-image
+  - deploy.vault-operator
 spec:
   namespace: secrets-webhook
   chart:
@@ -46,5 +33,5 @@ spec:
     - ./e2e/deploy/secrets-webhook/values.yaml
   values:
     image:
-      repository: ${var.repository}
-      tag: ${var.tag}
+      repository: ${actions.build.secrets-webhook-image.outputs.deployment-image-name}
+      tag: ${actions.build.secrets-webhook-image.version}

--- a/project.garden.yaml
+++ b/project.garden.yaml
@@ -21,3 +21,4 @@ scan:
     - .devenv/**/*
     - build/**/*
     - e2e/**/*
+    - examples/**/*


### PR DESCRIPTION
## Overview

- Removed the workaround in the CI.
- Fixed deploying with garden.

Fixes #20 #19

## Notes for reviewer

- Garden deploys blazingly fast, and sometimes the Vault service wasn't ready, so I removed it from `garden.yaml`, and made it common within the e2e test itself for both `BOOTSTRAP` and `USE_REAL_CLUSTER` cases because [this](https://github.com/bank-vaults/secrets-webhook/blob/44e97a55e446774eb1e19dc3d782db77c37f3a51/e2e/main_test.go#L264-L266) piece of code ensures that the Vault service will be ready.
