### PR TITLE
feat: support _json_key when mutating docker credentials

### DIFF
--- a/pkg/provider/bao/secret.go
+++ b/pkg/provider/bao/secret.go
@@ -78,41 +78,28 @@ func mutateDockerCreds(secret *corev1.Secret, dc *common.DockerCredentials, inje
 	assembled := common.DockerCredentials{Auths: map[string]common.DockerAuthConfig{}}
 
 	for key, creds := range dc.Auths {
-		authBytes, err := base64.StdEncoding.DecodeString(creds.Auth)
+		authBytes, err := base64.StdEncoding.DecodeString(creds.Auth.(string))
 		if err != nil {
 			return errors.Wrap(err, "auth base64 decoding failed")
 		}
 
-		auth := string(authBytes)
-		if isValidPrefix(auth) {
-			split := strings.Split(auth, ":")
-			if len(split) != 4 {
-				return errors.New("splitting auth credentials failed")
+		if isValidPrefix(string(authBytes)) {
+			authCreds, err := determineAuthType(authBytes)
+			if err != nil {
+				return errors.Wrap(err, "handling auth failed")
 			}
 
-			username := fmt.Sprintf("%s:%s", split[0], split[1])
-			password := fmt.Sprintf("%s:%s", split[2], split[3])
-			credentialData := map[string]string{
-				"username": username,
-				"password": password,
+			credentialData, err := common.AssembleCredentialData(authCreds)
+			if err != nil {
+				return errors.Wrap(err, "assembling credential data failed")
 			}
 
 			dcCreds, err := injector.GetDataFromBao(credentialData)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "retrieving data from bao failed")
 			}
 
-			auth = fmt.Sprintf("%s:%s", dcCreds["username"], dcCreds["password"])
-			dockerAuth := common.DockerAuthConfig{
-				Auth: base64.StdEncoding.EncodeToString([]byte(auth)),
-			}
-
-			if creds.Username != "" && creds.Password != "" {
-				dockerAuth.Username = dcCreds["username"]
-				dockerAuth.Password = dcCreds["password"]
-			}
-
-			assembled.Auths[key] = dockerAuth
+			assembled.Auths[key] = common.AssembleDockerAuthConfig(dcCreds, creds)
 		}
 	}
 
@@ -154,14 +141,35 @@ func secretNeedsMutation(secret *corev1.Secret) (bool, error) {
 			}
 
 			for _, creds := range dc.Auths {
-				authBytes, err := base64.StdEncoding.DecodeString(creds.Auth)
-				if err != nil {
-					return false, errors.Wrap(err, "auth base64 decoding failed")
-				}
+				switch creds.Auth.(type) {
+				case string:
+					authBytes, err := base64.StdEncoding.DecodeString(creds.Auth.(string))
+					if err != nil {
+						return false, errors.Wrap(err, "auth base64 decoding failed")
+					}
 
-				auth := string(authBytes)
-				if isValidPrefix(auth) {
-					return true, nil
+					auth := string(authBytes)
+					if isValidPrefix(auth) {
+						return true, nil
+					}
+
+				case map[string]interface{}:
+					// get sub-keys from the auth field
+					authMap, ok := creds.Auth.(map[string]interface{})
+					if !ok {
+						return false, errors.New("invalid auth type")
+					}
+
+					// check if any of the sub-keys have a vault prefix
+					for _, v := range authMap {
+						if isValidPrefix(v.(string)) {
+							return true, nil
+						}
+					}
+					return false, nil
+
+				default:
+					return false, errors.New("invalid auth type")
 				}
 			}
 
@@ -173,4 +181,34 @@ func secretNeedsMutation(secret *corev1.Secret) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// determineAuthType takes a byte slice of authentication data and determines its type.
+// It supports three formats: "username:usr:password:pass", JSON keys, and valid vault paths.
+func determineAuthType(auth []byte) (map[string]string, error) {
+	creds := make(map[string]string)
+
+	// if the auth string is formatted as "username:usr:password:pass",
+	// split the string into username and password
+	split := strings.Split(string(auth), ":")
+	if len(split) == 4 {
+		creds["username"] = fmt.Sprintf("%s:%s", split[0], split[1])
+		creds["password"] = fmt.Sprintf("%s:%s", split[2], split[3])
+
+		return creds, nil
+	}
+
+	// if the auth string is a JSON key, don't split and use it as is
+	if json.Valid(auth) {
+		creds["auth"] = string(auth)
+		return creds, nil
+	}
+
+	// if none of the above, the auth string can still be a valid vault path
+	if isValidPrefix(string(auth)) {
+		creds["auth"] = string(auth)
+		return creds, nil
+	}
+
+	return nil, errors.New("invalid auth string")
 }


### PR DESCRIPTION
## Overview

- Made the `Auth` field of type `interface{}`, because this way when a `_json_key` is received under the `auth` key of a `.dockerconfigjson` it can be handled.
- I left the username, password splitting case as it was, and added a check for `_json_key` and another check, if a vault path is received upfront at the `auth` key.

Fixes: https://github.com/bank-vaults/vault-secrets-webhook/issues/81

## Notes for reviewers

- I tested the new functionality with these 3 `dockerconfigjson` secrets. The passing e2e tests prove that the already implemented username, password authentication option is still working. 

```yaml
# test.yaml
# For this to work, run: vault kv put secret/test/mysql MYSQL_PASSWORD=3xtr3ms3cr3t
# Decoded structure of data:
# {
#   "auths": {
#     "https://myrepov": {
#       "auth": "vault:secret/data/test/mysql#MYSQL_PASSWORD"
#     }
#   }
# }

apiVersion: v1
kind: Secret
type: kubernetes.io/dockerconfigjson
metadata:
  name: broken-thing
  annotations:
    vault.security.banzaicloud.io/vault-skip-verify: "true"
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215cmVwb3YiOnsiYXV0aCI6ImRtRjFiSFE2YzJWamNtVjBMMlJoZEdFdmRHVnpkQzl0ZVhOeGJDTk5XVk5SVEY5UVFWTlRWMDlTUkE9PSJ9fX0=
```

#### After mutation:

<img width="1120" alt="image" src="https://github.com/bank-vaults/secrets-webhook/assets/113284287/8c7de5f9-59ba-4298-a103-6f05caa82abc">


```yaml
# test2.yaml
# Decoded structure of data:
# {
#   "auths": {
#     "https://myrepov": {
#       "auth": {
#         "type": "service_account",
#         "project_id": "fake-project"
#       }
#     }
#   }
# }

apiVersion: v1
kind: Secret
type: kubernetes.io/dockerconfigjson
metadata:
  name: docker-secret
  annotations:
    vault.security.banzaicloud.io/vault-skip-verify: "true"
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215cmVwb3YiOnsiYXV0aCI6eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwicHJvamVjdF9pZCI6ImZha2UtcHJvamVjdCJ9fX19
```

#### After mutation:

<img width="1151" alt="image" src="https://github.com/bank-vaults/secrets-webhook/assets/113284287/45a03c85-b51b-45fb-90ba-5e83ce627554">

```yaml
# test3.yaml
# For this to work, run: vault kv put secret/test/aws AWS_SECRET_ACCESS_KEY=s3cr3t
# Decoded structure:
# {
#   "auths": {
#     "https://myrepov": {
#       "auth": "vault:secret/data/test/aws#AWS_SECRET_ACCESS_KEY"
#     }
#   }
# }

apiVersion: v1
kind: Secret
type: kubernetes.io/dockerconfigjson
metadata:
  name: aws-key-secret
  annotations:
    vault.security.banzaicloud.io/vault-skip-verify: "true"
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215cmVwb3YiOnsiYXV0aCI6ImRtRjFiSFE2YzJWamNtVjBMMlJoZEdFdmRHVnpkQzloZDNNalFWZFRYMU5GUTFKRlZGOUJRME5GVTFOZlMwVloifX19
```

#### After mutation:

<img width="1123" alt="image" src="https://github.com/bank-vaults/secrets-webhook/assets/113284287/5031f2e4-7e92-477f-bfb1-f321112852fd">

#### e2e-secret after mutation:

<img width="1671" alt="image" src="https://github.com/bank-vaults/secrets-webhook/assets/113284287/659b8864-95ee-4867-a402-bfc9fc0e78a8">
