### PR TITLE
feat: improve e2e tests

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -64,8 +64,7 @@ func TestMain(m *testing.M) {
 
 	// Set up cluster
 	if useRealCluster {
-		path := conf.ResolveKubeConfigFile()
-		cfg := envconf.NewWithKubeConfig(path)
+		cfg := envconf.NewWithKubeConfig(conf.ResolveKubeConfigFile())
 
 		if context := os.Getenv("USE_CONTEXT"); context != "" {
 			cfg.WithKubeContext(context)
@@ -232,8 +231,6 @@ func (e *reverseFinishEnvironment) Run(m *testing.M) int {
 
 	return e.Environment.Run(m)
 }
-
-// ======== VAULT ========
 
 func installVault(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 	r, err := resources.New(cfg.Client().RESTConfig())

--- a/e2e/test/deployment-init-seccontext-vault.yaml
+++ b/e2e/test/deployment-init-seccontext-vault.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: alpine
           image: alpine
-          command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
+          command: ["sh", "-c", "echo AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
           env:
           - name: AWS_SECRET_ACCESS_KEY
             value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY

--- a/e2e/test/deployment-seccontext-vault.yaml
+++ b/e2e/test/deployment-seccontext-vault.yaml
@@ -25,7 +25,7 @@ spec:
       initContainers:
       - name: init-ubuntu
         image: ubuntu
-        command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo initContainers ready"]
+        command: ["sh", "-c", "echo AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && echo initContainers ready"]
         env:
         - name: AWS_SECRET_ACCESS_KEY
           value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
@@ -36,7 +36,7 @@ spec:
       containers:
       - name: alpine
         image: alpine
-        command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
+        command: ["sh", "-c", "echo AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
         env:
         - name: AWS_SECRET_ACCESS_KEY
           value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY

--- a/e2e/test/deployment-vault.yaml
+++ b/e2e/test/deployment-vault.yaml
@@ -22,7 +22,7 @@ spec:
       initContainers:
       - name: init-ubuntu
         image: ubuntu
-        command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo initContainers ready"]
+        command: ["sh", "-c", "echo AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && echo initContainers ready"]
         env:
         - name: AWS_SECRET_ACCESS_KEY
           value: vault:secret/data/accounts/aws#${.AWS_SECRET_ACCESS_KEY} # Go templates are also supported with ${} delimiters
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: alpine
         image: alpine
-        command: ["sh", "-c", "echo $AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
+        command: ["sh", "-c", "echo AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && echo going to sleep... && sleep 10000"]
         env:
         - name: AWS_SECRET_ACCESS_KEY
           value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Overview
- I added a function that can retrieve the logs of containers, and since we log the secrets already, it proves to be a great opportunity to verify the success of secret injection.
- I found an issue on the old webhook repo https://github.com/bank-vaults/vault-secrets-webhook/issues/6.
- I don't believe it would be useful to check the existence of Secret-Init injected into the resource, since the tests would fail if that did not happen. Moreover, executing Secret-Init again is not something that we encourage or recommend doing, so in my opinion, it falls far from a real-world use case.

## As a result of these changes:

1. Injection is tested in case of all supported resource types:
- Config Map
- Secret
- Pod
- CRD (deploying a Vault CR creates admission review requests.)

2. Successful secret injection is verified for pods.

Fixes: https://github.com/bank-vaults/vault-secrets-webhook/issues/6
