### PR TITLE
chore: remove obsolete build tag

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/pkg/provider/vault/configmap_test.go
+++ b/pkg/provider/vault/configmap_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build integration
-// +build integration
 
 package vault
 


### PR DESCRIPTION
## Overview

- Removes obsolete build tag.

Fixes: https://github.com/orgs/bank-vaults/projects/2/views/1?pane=issue&itemId=38350173
