### PR TITLE
fix: missing agent-secrets volume when running vault-agent as initContainer

### DIFF
--- a/pkg/provider/vault/pod.go
+++ b/pkg/provider/vault/pod.go
@@ -177,6 +177,10 @@ func (m *mutator) MutatePod(ctx context.Context, mutateRequest provider.PodMutat
 		m.logger.Debug("Successfully appended pod spec volumes")
 	}
 
+	if m.config.AgentConfigMap != "" && m.config.UseAgent {
+		m.addAgentSecretsVolToContainers(mutateRequest.Pod.Spec.Containers)
+	}
+
 	if m.config.AgentConfigMap != "" && !m.config.UseAgent {
 		m.logger.Debug("Vault Agent config found")
 
@@ -598,6 +602,13 @@ func (m *mutator) getInitContainers(originalContainers []corev1.Container, podSe
 			Name:      "vault-agent-config",
 			MountPath: "/vault/agent/",
 		})
+
+		if m.config.CtConfigMap == "" {
+			containerVolMounts = append(containerVolMounts, corev1.VolumeMount{
+				Name:      "agent-secrets",
+				MountPath: m.config.ConfigfilePath,
+			})
+		}
 
 		securityContext := common.GetBaseSecurityContext(podSecurityContext, webhookConfig)
 		securityContext.Capabilities.Add = []corev1.Capability{

--- a/pkg/provider/vault/pod_test.go
+++ b/pkg/provider/vault/pod_test.go
@@ -1695,6 +1695,200 @@ func Test_mutator_mutatePod(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Will mutate pod and add agent-secrets volume when running vault agent as initcontainer",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+				registry: &MockRegistry{
+					Image: v1.Config{},
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name:    "MyInitContainer",
+								Image:   "myInitimage",
+								Command: []string{"/bin/bash"},
+								Args:    nil,
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/var/run/secrets/vault",
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{
+								Name:    "MyContainer",
+								Image:   "myimage",
+								Command: []string{"/bin/bash"},
+								Args:    nil,
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/var/run/secrets/vault",
+									},
+								},
+							},
+						},
+					},
+				},
+				webhookConfig: appCommon.Config{
+					RunAsNonRoot: true,
+					RunAsUser:    int64(1000),
+					RunAsGroup:   int64(1000),
+				},
+				secretInitConfig: appCommon.SecretInitConfig{
+					CPURequest:    resource.MustParse("50m"),
+					MemoryRequest: resource.MustParse("64Mi"),
+					CPULimit:      resource.MustParse("250m"),
+					MemoryLimit:   resource.MustParse("64Mi"),
+				},
+				vaultConfig: Config{
+					AgentConfigMap: "config-map-test",
+					UseAgent:       true,
+					ConfigfilePath: "/vault/secrets",
+					// the rest are just defaults for the wantedPod spec..
+					Addr:                 "test",
+					SkipVerify:           false,
+					AgentImage:           "hashicorp/vault:latest",
+					AgentImagePullPolicy: "IfNotPresent",
+					// EnvCPURequest:                 resource.MustParse("50m"),
+					// EnvMemoryRequest:              resource.MustParse("64Mi"),
+					// EnvCPULimit:                   resource.MustParse("250m"),
+					// EnvMemoryLimit:                resource.MustParse("64Mi"),
+					ServiceAccountTokenVolumeName: "/var/run/secrets/vault",
+					// RunAsNonRoot:                  true,
+					// RunAsUser:                     int64(1000),
+					// RunAsGroup:                    int64(1000),
+				},
+			},
+			wantedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            "vault-agent",
+							Image:           "hashicorp/vault:latest",
+							Command:         []string{"vault", "agent", "-config=/vault/agent/config.hcl", "-exit-after-auth"},
+							ImagePullPolicy: "IfNotPresent",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "VAULT_ADDR",
+									Value: "test",
+								},
+								{
+									Name:  "VAULT_SKIP_VERIFY",
+									Value: "false",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							SecurityContext: agentInitContainerSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "secret-init",
+									MountPath: "/vault/",
+								},
+								{
+									MountPath: "/var/run/secrets/vault",
+								},
+								{
+									Name:      "vault-agent-config",
+									MountPath: "/vault/agent/",
+								},
+								{
+									Name:      "agent-secrets",
+									MountPath: "/vault/secrets",
+								},
+							},
+						},
+						{
+							Name:    "MyInitContainer",
+							Image:   "myInitimage",
+							Command: []string{"/bin/bash"},
+							Args:    nil,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/var/run/secrets/vault",
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:    "MyContainer",
+							Image:   "myimage",
+							Command: []string{"/bin/bash"},
+							Args:    nil,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/var/run/secrets/vault",
+								},
+								{
+									Name:      "agent-secrets",
+									MountPath: "/vault/secrets",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "secret-init",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+						{
+							Name: "vault-agent-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-map-test",
+									},
+								},
+							},
+						},
+						{
+							Name: "agent-secrets",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+						{
+							Name: "agent-configmap",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-map-test",
+									},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  "config.hcl",
+											Path: "config.hcl",
+										},
+									},
+									DefaultMode: &defaultMode,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview

When running the vault (or bao) agent as initContainer the agent-secrets volume is now added to the PodSpec and VolumeMounts are added to relevant containers.

## Notes for reviewer

Backport of https://github.com/bank-vaults/vault-secrets-webhook/pull/644
