### PR TITLE
fix: allow specifying provider via PROVIDER env variable

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -161,6 +161,7 @@ const (
 	ListenAddressEnvVar               = "listen_address"
 	TelemetryListenAddressEnvVar      = "telemetry_listen_address"
 	LogLevelEnvVar                    = "log_level"
+	ProviderEnvVar                    = "provider"
 
 	// Secret-init environment variables
 	SecretInitDaemonEnvVar          = "secret_init_daemon"

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -103,6 +103,8 @@ func LoadWebhookConfig(annotations map[string]string) Config {
 
 	if val, ok := annotations[ProviderAnnotation]; ok {
 		config.Provider = val
+	} else {
+		config.Provider = viper.GetString("PROVIDER")
 	}
 
 	return config

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -104,7 +104,7 @@ func LoadWebhookConfig(annotations map[string]string) Config {
 	if val, ok := annotations[ProviderAnnotation]; ok {
 		config.Provider = val
 	} else {
-		config.Provider = viper.GetString("PROVIDER")
+		config.Provider = viper.GetString(ProviderEnvVar)
 	}
 
 	return config


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Allow specifying provider via PROVIDER environment variable

This change allows users to specify the secrets-webhook provider through an environment variable (PROVIDER), reducing the need to annotate each Kubernetes resource explicitly.

Currently, annotations like this is required:

```yaml
annotations:
  secrets-webhook.security.bank-vaults.io/provider: "vault"
```

With this change, users can set the provider centrally via the webhook deployment environment, e.g.:
```yaml
env:
  PROVIDER: "vault"
```

Annotations remain the primary method and override the environment variable when set.

### Why this change?

* Simplifies deployments by centralizing configuration.
* Brings consistency with existing environment-variable-based configurations

Fixes #(issue)
See: https://cloud-native.slack.com/archives/C078PHYK38W/p1739438975607409

## Notes for reviewer
In regards to slack discussion: https://cloud-native.slack.com/archives/C078PHYK38W/p1739438975607409

