### PR TITLE
feat(helm): added flag to enable mutations in deployment namespace

### DIFF
--- a/deploy/charts/secrets-webhook/templates/apiservice-webhook.yaml
+++ b/deploy/charts/secrets-webhook/templates/apiservice-webhook.yaml
@@ -148,10 +148,12 @@ webhooks:
     {{- if $podsNamespaceSelector.matchExpressions }}
 {{ toYaml $podsNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
+    {{- if .Values.ignoreReleaseNamespace }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+    {{- end }}
 {{- if semverCompare ">=1.15-0" (include "secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if $podsObjectSelector.matchLabels }}
@@ -213,10 +215,12 @@ webhooks:
     {{- if $secretsNamespaceSelector.matchExpressions }}
 {{ toYaml $secretsNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
+    {{- if .Values.ignoreReleaseNamespace }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+    {{- end }}
 {{- if semverCompare ">=1.15-0" (include "secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if $secretsObjectSelector.matchLabels }}
@@ -283,10 +287,12 @@ webhooks:
   {{- if $configmapsNamespaceSelector.matchExpressions }}
 {{ toYaml $configmapsNamespaceSelector.matchExpressions | indent 4 }}
   {{- end }}
+    {{- if .Values.ignoreReleaseNamespace }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+    {{- end }}
 {{- if semverCompare ">=1.15-0" (include "secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if $configmapsObjectSelector.matchLabels }}
@@ -350,10 +356,12 @@ webhooks:
     {{- if $crNamespaceSelector.matchExpressions }}
 {{ toYaml $crNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
+    {{- if .Values.ignoreReleaseNamespace }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+    {{- end }}
 {{- if semverCompare ">=1.15-0" (include "secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if $crObjectSelector.matchLabels }}

--- a/deploy/charts/secrets-webhook/values.yaml
+++ b/deploy/charts/secrets-webhook/values.yaml
@@ -244,6 +244,10 @@ secretsFailurePolicy: Ignore
 # Check: <https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects>
 apiSideEffectValue: NoneOnDryRun
 
+# -- Enables the webhook to ignore resources in the namespace it is deployed to.
+# Set to `false` to enable mutations within the namespace the webhook runs in.
+ignoreReleaseNamespace: true
+
 # -- Namespace selector to use, will limit webhook scope (K8s version 1.15+)
 namespaceSelector:
   # @ignored


### PR DESCRIPTION
Changes:
- selector is preventing resources in same ns as the webhook is deployed to are mutated
- this behaviour is already ensured by security.banzaicloud.io/mutate annotation

Motivation:

Within my environment I want to create Pods altered by the Webhook within the same Namespace as the Webhook runs in