### PR TITLE
feat: validate object-supplied Vault/Bao addresses

### DIFF
--- a/deploy/charts/secrets-webhook/values.yaml
+++ b/deploy/charts/secrets-webhook/values.yaml
@@ -79,6 +79,14 @@ secretInit:
 env: {}
   ## -- Vault image
   # VAULT_IMAGE: hashicorp/vault:2.0.1
+
+  ## -- Object-annotation hardening
+  # VAULT_ADDR_ALLOWLIST: "https://vault.prod.svc:8200,https://vault.dr.svc:8200"
+  # BAO_ADDR_ALLOWLIST: "https://bao.prod.svc:8300"
+  # VAULT_ALLOW_OBJECT_SKIP_VERIFY: "false"
+  # BAO_ALLOW_OBJECT_SKIP_VERIFY: "false"
+  # VAULT_ALLOW_PRIVATE_ADDR: "false"
+  # BAO_ALLOW_PRIVATE_ADDR: "false"
   # VAULT_CAPATH: /vault/tls
 
   ## -- Used when the pod that should get secret injected does not specify an imagePullSecret

--- a/e2e/deploy/secrets-webhook/values.yaml
+++ b/e2e/deploy/secrets-webhook/values.yaml
@@ -1,5 +1,6 @@
 env:
   VAULT_IMAGE: hashicorp/vault:2.0.1
+  VAULT_ADDR_ALLOWLIST: "https://vault.default.svc.cluster.local:8200"
 
 replicaCount: 1
 

--- a/pkg/common/addr.go
+++ b/pkg/common/addr.go
@@ -1,0 +1,160 @@
+// Copyright © 2026 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"emperror.dev/errors"
+)
+
+// AddrPolicy constrains an address taken from an untrusted object annotation.
+type AddrPolicy struct {
+	Allowlist    []string
+	AllowPrivate bool
+}
+
+var metadataHosts = map[string]struct{}{
+	"localhost":                {},
+	"metadata.google.internal": {},
+}
+
+// RFC 6598 shared address space (100.64.0.0/10), used by some cloud IMDS.
+var cgnatRange = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
+// ValidateObjectAddr vets an object-supplied address against the operator
+// allowlist and an SSRF guard. Operator-configured addresses are trusted and
+// must not be passed here.
+func ValidateObjectAddr(addr string, policy AddrPolicy) error {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return errors.New("address is empty")
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return errors.Wrapf(err, "malformed address %q", addr)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return errors.Errorf("address %q has unsupported scheme %q (only http and https are allowed)", addr, u.Scheme)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return errors.Errorf("address %q has no host", addr)
+	}
+
+	if u.User != nil {
+		return errors.Errorf("address %q must not contain user credentials", addr)
+	}
+
+	if u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return errors.Errorf("address %q must not contain a query string or fragment", addr)
+	}
+
+	if !addrInAllowlist(addr, policy.Allowlist) {
+		return errors.Errorf("address %q is not in the configured allowlist", addr)
+	}
+
+	// Metadata hosts are blocked unconditionally.
+	if _, ok := metadataHosts[strings.ToLower(host)]; ok {
+		return errors.Errorf("address %q targets a metadata host, which is never allowed", addr)
+	}
+
+	if !policy.AllowPrivate {
+		if err := checkHostIPSafety(host); err != nil {
+			return errors.Wrapf(err, "address %q", addr)
+		}
+	}
+
+	return nil
+}
+
+func addrInAllowlist(addr string, allowlist []string) bool {
+	target := normalizeAddr(addr)
+	for _, entry := range allowlist {
+		if strings.TrimSpace(entry) == "" {
+			continue
+		}
+		if normalizeAddr(entry) == target {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeAddr(addr string) string {
+	u, err := url.Parse(strings.TrimSpace(addr))
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(addr))
+	}
+
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + strings.TrimSuffix(u.Path, "/")
+}
+
+// checkHostIPSafety rejects loopback/link-local/private/CGNAT targets. DNS is
+// not resolved here (to avoid resolve-time rebinding); hostnames rely on the allowlist.
+func checkHostIPSafety(host string) error {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		if looksLikeNumericIP(host) {
+			return errors.Errorf("has an ambiguous numeric IP literal host %q", host)
+		}
+
+		return nil
+	}
+
+	if isUnsafeIP(ip) {
+		return errors.Errorf("targets a loopback, link-local, private, or shared-address-space host %q", host)
+	}
+
+	return nil
+}
+
+func isUnsafeIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsPrivate() ||
+		ip.IsUnspecified() ||
+		cgnatRange.Contains(ip)
+}
+
+// looksLikeNumericIP catches non-standard IPv4 forms (octal/decimal/hex) that
+// net.ParseIP rejects but an OS resolver may still treat as an address.
+func looksLikeNumericIP(host string) bool {
+	if strings.HasPrefix(strings.ToLower(host), "0x") {
+		return true
+	}
+
+	hasDigit := false
+	for _, r := range host {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '.':
+		default:
+			return false
+		}
+	}
+
+	return hasDigit
+}

--- a/pkg/common/addr_test.go
+++ b/pkg/common/addr_test.go
@@ -1,0 +1,180 @@
+// Copyright © 2026 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateObjectAddr(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		policy  AddrPolicy
+		wantErr bool
+	}{
+		{
+			name:    "empty address is rejected",
+			addr:    "",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "allowlisted public https address is accepted",
+			addr:    "https://vault.prod.svc:8200",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: false,
+		},
+		{
+			name:    "address not in allowlist is rejected (default-deny)",
+			addr:    "https://evil.attacker.com",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "empty allowlist denies every object override",
+			addr:    "https://vault.prod.svc:8200",
+			policy:  AddrPolicy{Allowlist: nil},
+			wantErr: true,
+		},
+		{
+			name:    "non-http scheme is rejected",
+			addr:    "file:///etc/passwd",
+			policy:  AddrPolicy{Allowlist: []string{"file:///etc/passwd"}},
+			wantErr: true,
+		},
+		{
+			name:    "address without scheme is rejected",
+			addr:    "169.254.169.254",
+			policy:  AddrPolicy{Allowlist: []string{"169.254.169.254"}},
+			wantErr: true,
+		},
+		{
+			name:    "IMDS link-local is rejected even when allowlisted",
+			addr:    "http://169.254.169.254/latest/meta-data/",
+			policy:  AddrPolicy{Allowlist: []string{"http://169.254.169.254/latest/meta-data/"}},
+			wantErr: true,
+		},
+		{
+			name:    "loopback IP literal is rejected by default",
+			addr:    "http://127.0.0.1:8200",
+			policy:  AddrPolicy{Allowlist: []string{"http://127.0.0.1:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "private RFC1918 IP literal is rejected by default",
+			addr:    "https://10.0.0.5:8200",
+			policy:  AddrPolicy{Allowlist: []string{"https://10.0.0.5:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "private IP literal is accepted when operator allows private",
+			addr:    "https://10.0.0.5:8200",
+			policy:  AddrPolicy{Allowlist: []string{"https://10.0.0.5:8200"}, AllowPrivate: true},
+			wantErr: false,
+		},
+		{
+			name:    "metadata hostname is rejected by default",
+			addr:    "http://metadata.google.internal/computeMetadata/v1/",
+			policy:  AddrPolicy{Allowlist: []string{"http://metadata.google.internal/computeMetadata/v1/"}},
+			wantErr: true,
+		},
+		{
+			name:    "localhost hostname is rejected by default",
+			addr:    "http://localhost:8200",
+			policy:  AddrPolicy{Allowlist: []string{"http://localhost:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "allowlist match is normalized (trailing slash and case)",
+			addr:    "https://Vault.Prod.SVC:8200/",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: false,
+		},
+		{
+			name:    "cluster hostname override is accepted when allowlisted",
+			addr:    "https://vault-dr.vault-system.svc:8200",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.vault-system.svc:8200", "https://vault-dr.vault-system.svc:8200"}},
+			wantErr: false,
+		},
+		{
+			name:    "userinfo credentials are rejected even when host is allowlisted",
+			addr:    "https://attacker:pw@vault.prod.svc:8200",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "query string is rejected",
+			addr:    "https://vault.prod.svc:8200?x=1",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "fragment is rejected",
+			addr:    "https://vault.prod.svc:8200#frag",
+			policy:  AddrPolicy{Allowlist: []string{"https://vault.prod.svc:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "metadata hostname is rejected even when private addresses are allowed",
+			addr:    "http://metadata.google.internal/computeMetadata/v1/",
+			policy:  AddrPolicy{Allowlist: []string{"http://metadata.google.internal/computeMetadata/v1/"}, AllowPrivate: true},
+			wantErr: true,
+		},
+		{
+			name:    "localhost is rejected even when private addresses are allowed",
+			addr:    "http://localhost:8200",
+			policy:  AddrPolicy{Allowlist: []string{"http://localhost:8200"}, AllowPrivate: true},
+			wantErr: true,
+		},
+		{
+			name:    "decimal IP literal for loopback is rejected",
+			addr:    "http://2130706433:8200",
+			policy:  AddrPolicy{Allowlist: []string{"http://2130706433:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "octal IP literal for loopback is rejected",
+			addr:    "http://0177.0.0.1:8200",
+			policy:  AddrPolicy{Allowlist: []string{"http://0177.0.0.1:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "hex IP literal is rejected",
+			addr:    "http://0x7f000001:8200",
+			policy:  AddrPolicy{Allowlist: []string{"http://0x7f000001:8200"}},
+			wantErr: true,
+		},
+		{
+			name:    "CGNAT shared-address-space IMDS is rejected",
+			addr:    "http://100.100.100.200/latest/meta-data/",
+			policy:  AddrPolicy{Allowlist: []string{"http://100.100.100.200/latest/meta-data/"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateObjectAddr(tt.addr, tt.policy)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -201,6 +201,9 @@ const (
 	VaultTokenEnvVar                      = "vault_token"
 	VaultSAEnvVar                         = "vault_serviceaccount"
 	VaultSATokenVolumeNameEnvVar          = "vault_service_account_token_volume_name"
+	VaultAddrAllowlistEnvVar              = "vault_addr_allowlist"
+	VaultAllowObjectSkipVerifyEnvVar      = "vault_allow_object_skip_verify"
+	VaultAllowPrivateAddrEnvVar           = "vault_allow_private_addr"
 
 	// Bao environment variables
 	BaoImageEnvVar                      = "bao_image"
@@ -227,6 +230,9 @@ const (
 	BaoTokenEnvVar                      = "bao_token"
 	BaoSAEnvVar                         = "bao_serviceaccount"
 	BaoSATokenVolumeNameEnvVar          = "bao_service_account_token_volume_name"
+	BaoAddrAllowlistEnvVar              = "bao_addr_allowlist"
+	BaoAllowObjectSkipVerifyEnvVar      = "bao_allow_object_skip_verify"
+	BaoAllowPrivateAddrEnvVar           = "bao_allow_private_addr"
 
 	// AWS environment variables
 	AWSRegionEnvVar                = "aws_region"

--- a/pkg/common/policy.go
+++ b/pkg/common/policy.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// SplitAndTrim splits a comma-separated value, dropping empty entries.
+func SplitAndTrim(csv string) []string {
+	if strings.TrimSpace(csv) == "" {
+		return nil
+	}
+
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+
+	return out
+}
+
+// ResolveObjectSkipVerify honors an object-supplied skip-verify annotation only
+// when the operator opted in (allowEnvVar); otherwise it returns the operator default.
+func ResolveObjectSkipVerify(annotationValue, allowEnvVar, defaultEnvVar string) bool {
+	requested, _ := strconv.ParseBool(annotationValue)
+	if viper.GetBool(allowEnvVar) {
+		return requested
+	}
+
+	if requested {
+		slog.Warn("ignoring object skip-verify annotation; operator opt-in required",
+			slog.String("allow_env", allowEnvVar))
+	}
+
+	return viper.GetBool(defaultEnvVar)
+}

--- a/pkg/common/policy_test.go
+++ b/pkg/common/policy_test.go
@@ -1,0 +1,59 @@
+// Copyright © 2026 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitAndTrim(t *testing.T) {
+	assert.Nil(t, SplitAndTrim(""))
+	assert.Nil(t, SplitAndTrim("   "))
+	assert.Equal(t, []string{"a"}, SplitAndTrim("a"))
+	assert.Equal(t, []string{"a", "b"}, SplitAndTrim(" a , b "))
+	assert.Equal(t, []string{"a", "b"}, SplitAndTrim("a,,b,"))
+}
+
+func TestResolveObjectSkipVerify(t *testing.T) {
+	const allowEnv = "test_allow_object_skip_verify"
+	const defaultEnv = "test_skip_verify"
+
+	tests := []struct {
+		name            string
+		annotationValue string
+		allow           bool
+		operatorDefault bool
+		want            bool
+	}{
+		{name: "annotation true ignored by default falls back to operator default false", annotationValue: "true", allow: false, operatorDefault: false, want: false},
+		{name: "annotation true ignored by default falls back to operator default true", annotationValue: "true", allow: false, operatorDefault: true, want: true},
+		{name: "annotation true honored when opted in", annotationValue: "true", allow: true, operatorDefault: false, want: true},
+		{name: "annotation false honored when opted in", annotationValue: "false", allow: true, operatorDefault: true, want: false},
+		{name: "annotation false ignored by default falls back to operator default", annotationValue: "false", allow: false, operatorDefault: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Set(allowEnv, tt.allow)
+			viper.Set(defaultEnv, tt.operatorDefault)
+			t.Cleanup(viper.Reset)
+
+			assert.Equal(t, tt.want, ResolveObjectSkipVerify(tt.annotationValue, allowEnv, defaultEnv))
+		})
+	}
+}

--- a/pkg/provider/bao/config.go
+++ b/pkg/provider/bao/config.go
@@ -85,10 +85,18 @@ func LoadConfig(obj metav1.Object) (Config, error) {
 
 	annotations := obj.GetAnnotations()
 
+	addrFromObject := false
 	if val, ok := annotations[common.BaoAddrAnnotation]; ok {
 		config.Addr = val
+		addrFromObject = true
 	} else {
 		config.Addr = viper.GetString(common.BaoAddrEnvVar)
+	}
+
+	if addrFromObject {
+		if err := common.ValidateObjectAddr(config.Addr, baoAddrPolicy()); err != nil {
+			return Config{}, errors.Wrap(err, "rejected Bao address from object annotation")
+		}
 	}
 
 	if val, ok := annotations[common.BaoRoleAnnotation]; ok {
@@ -126,7 +134,7 @@ func LoadConfig(obj metav1.Object) (Config, error) {
 	}
 
 	if val, ok := annotations[common.BaoSkipVerifyAnnotation]; ok {
-		config.SkipVerify, _ = strconv.ParseBool(val)
+		config.SkipVerify = common.ResolveObjectSkipVerify(val, common.BaoAllowObjectSkipVerifyEnvVar, common.BaoSkipVerifyEnvVar)
 	} else {
 		config.SkipVerify = viper.GetBool(common.BaoSkipVerifyEnvVar)
 	}
@@ -355,6 +363,18 @@ func LoadConfig(obj metav1.Object) (Config, error) {
 	return config, nil
 }
 
+func baoAddrPolicy() common.AddrPolicy {
+	allowlist := common.SplitAndTrim(viper.GetString(common.BaoAddrAllowlistEnvVar))
+	if addr := viper.GetString(common.BaoAddrEnvVar); addr != "" {
+		allowlist = append(allowlist, addr) // trusted operator default is implicitly allowed
+	}
+
+	return common.AddrPolicy{
+		Allowlist:    allowlist,
+		AllowPrivate: viper.GetBool(common.BaoAllowPrivateAddrEnvVar),
+	}
+}
+
 func setDefaults() {
 	viper.SetDefault(common.BaoImageEnvVar, "openbao/openbao:latest")
 	viper.SetDefault(common.BaoImagePullPolicyEnvVar, string(corev1.PullIfNotPresent))
@@ -362,6 +382,9 @@ func setDefaults() {
 	viper.SetDefault(common.BaoCTPullPolicyEnvVar, string(corev1.PullIfNotPresent))
 	viper.SetDefault(common.BaoAddrEnvVar, "https://bao:8300")
 	viper.SetDefault(common.BaoSkipVerifyEnvVar, "false")
+	viper.SetDefault(common.BaoAddrAllowlistEnvVar, "")
+	viper.SetDefault(common.BaoAllowObjectSkipVerifyEnvVar, "false")
+	viper.SetDefault(common.BaoAllowPrivateAddrEnvVar, "false")
 	viper.SetDefault(common.BaoPathEnvVar, "kubernetes")
 	viper.SetDefault(common.BaoAuthMethodEnvVar, "jwt")
 	viper.SetDefault(common.BaoRoleEnvVar, "")

--- a/pkg/provider/bao/config_test.go
+++ b/pkg/provider/bao/config_test.go
@@ -1,0 +1,125 @@
+// Copyright © 2026 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bao
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/bank-vaults/secrets-webhook/pkg/common"
+)
+
+func TestLoadConfig_AddressHardening(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		envVars        map[string]string
+		wantErr        bool
+		wantAddr       string
+		wantSkipVerify bool
+	}{
+		{
+			name: "object addr override rejected when not in allowlist",
+			annotations: map[string]string{
+				common.BaoAddrAnnotation: "https://evil.attacker.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "object addr override rejected for IMDS link-local",
+			annotations: map[string]string{
+				common.BaoAddrAnnotation: "http://169.254.169.254/latest/meta-data/",
+			},
+			envVars: map[string]string{
+				common.BaoAddrAllowlistEnvVar: "http://169.254.169.254/latest/meta-data/",
+			},
+			wantErr: true,
+		},
+		{
+			name: "object addr override accepted when allowlisted",
+			annotations: map[string]string{
+				common.BaoAddrAnnotation: "https://bao.prod.svc:8300",
+			},
+			envVars: map[string]string{
+				common.BaoAddrAllowlistEnvVar: "https://bao.prod.svc:8300",
+			},
+			wantErr:  false,
+			wantAddr: "https://bao.prod.svc:8300",
+		},
+		{
+			name:        "operator-configured addr is trusted and never validated",
+			annotations: map[string]string{},
+			envVars: map[string]string{
+				common.BaoAddrEnvVar: "https://10.0.0.5:8300",
+			},
+			wantErr:  false,
+			wantAddr: "https://10.0.0.5:8300",
+		},
+		{
+			name: "object skip-verify ignored by default",
+			annotations: map[string]string{
+				common.BaoAddrAnnotation:       "https://bao.prod.svc:8300",
+				common.BaoSkipVerifyAnnotation: "true",
+			},
+			envVars: map[string]string{
+				common.BaoAddrAllowlistEnvVar: "https://bao.prod.svc:8300",
+			},
+			wantErr:        false,
+			wantAddr:       "https://bao.prod.svc:8300",
+			wantSkipVerify: false,
+		},
+		{
+			name: "object skip-verify honored when operator opts in",
+			annotations: map[string]string{
+				common.BaoAddrAnnotation:       "https://bao.prod.svc:8300",
+				common.BaoSkipVerifyAnnotation: "true",
+			},
+			envVars: map[string]string{
+				common.BaoAddrAllowlistEnvVar:         "https://bao.prod.svc:8300",
+				common.BaoAllowObjectSkipVerifyEnvVar: "true",
+			},
+			wantErr:        false,
+			wantAddr:       "https://bao.prod.svc:8300",
+			wantSkipVerify: true,
+		},
+	}
+
+	for _, tt := range tests {
+		ttp := tt
+		t.Run(ttp.name, func(t *testing.T) {
+			for key, value := range ttp.envVars {
+				viper.Set(key, value)
+			}
+			t.Cleanup(func() {
+				viper.Reset()
+				os.Clearenv()
+			})
+
+			config, err := LoadConfig(&metav1.ObjectMeta{Annotations: ttp.annotations})
+			if ttp.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, ttp.wantAddr, config.Addr)
+			assert.Equal(t, ttp.wantSkipVerify, config.SkipVerify)
+		})
+	}
+}

--- a/pkg/provider/vault/config.go
+++ b/pkg/provider/vault/config.go
@@ -88,12 +88,21 @@ func loadConfig(obj metav1.Object) (Config, error) {
 
 	annotations := obj.GetAnnotations()
 
+	addrFromObject := false
 	if val, ok := annotations[common.VaultAddrAnnotation]; ok {
 		config.Addr = val
+		addrFromObject = true
 	} else if val, ok := annotations[common.VaultAddrAnnotationDeprecated]; ok {
 		config.Addr = val
+		addrFromObject = true
 	} else {
 		config.Addr = viper.GetString(common.VaultAddrEnvVar)
+	}
+
+	if addrFromObject {
+		if err := common.ValidateObjectAddr(config.Addr, vaultAddrPolicy()); err != nil {
+			return Config{}, errors.Wrap(err, "rejected Vault address from object annotation")
+		}
 	}
 
 	if val, ok := annotations[common.VaultRoleAnnotation]; ok {
@@ -139,9 +148,9 @@ func loadConfig(obj metav1.Object) (Config, error) {
 	}
 
 	if val, ok := annotations[common.VaultSkipVerifyAnnotation]; ok {
-		config.SkipVerify, _ = strconv.ParseBool(val)
+		config.SkipVerify = common.ResolveObjectSkipVerify(val, common.VaultAllowObjectSkipVerifyEnvVar, common.VaultSkipVerifyEnvVar)
 	} else if val, ok := annotations[common.VaultSkipVerifyAnnotationDeprecated]; ok {
-		config.SkipVerify, _ = strconv.ParseBool(val)
+		config.SkipVerify = common.ResolveObjectSkipVerify(val, common.VaultAllowObjectSkipVerifyEnvVar, common.VaultSkipVerifyEnvVar)
 	} else {
 		config.SkipVerify = viper.GetBool(common.VaultSkipVerifyEnvVar)
 	}
@@ -445,6 +454,18 @@ func loadConfig(obj metav1.Object) (Config, error) {
 	return config, nil
 }
 
+func vaultAddrPolicy() common.AddrPolicy {
+	allowlist := common.SplitAndTrim(viper.GetString(common.VaultAddrAllowlistEnvVar))
+	if addr := viper.GetString(common.VaultAddrEnvVar); addr != "" {
+		allowlist = append(allowlist, addr) // trusted operator default is implicitly allowed
+	}
+
+	return common.AddrPolicy{
+		Allowlist:    allowlist,
+		AllowPrivate: viper.GetBool(common.VaultAllowPrivateAddrEnvVar),
+	}
+}
+
 func setDefaults() {
 	viper.SetDefault(common.VaultImageEnvVar, "hashicorp/vault:latest")
 	viper.SetDefault(common.VaultImagePullPolicyEnvVar, string(corev1.PullIfNotPresent))
@@ -452,6 +473,9 @@ func setDefaults() {
 	viper.SetDefault(common.VaultCTPullPolicyEnvVar, string(corev1.PullIfNotPresent))
 	viper.SetDefault(common.VaultAddrEnvVar, "https://vault:8200")
 	viper.SetDefault(common.VaultSkipVerifyEnvVar, "false")
+	viper.SetDefault(common.VaultAddrAllowlistEnvVar, "")
+	viper.SetDefault(common.VaultAllowObjectSkipVerifyEnvVar, "false")
+	viper.SetDefault(common.VaultAllowPrivateAddrEnvVar, "false")
 	viper.SetDefault(common.VaultPathEnvVar, "kubernetes")
 	viper.SetDefault(common.VaultAuthMethodEnvVar, "jwt")
 	viper.SetDefault(common.VaultRoleEnvVar, "")

--- a/pkg/provider/vault/config_test.go
+++ b/pkg/provider/vault/config_test.go
@@ -36,6 +36,10 @@ func TestLoadConfig(t *testing.T) {
 	}{
 		{
 			name: "Handle deprecated annotations all",
+			envVars: map[string]string{
+				common.VaultAddrAllowlistEnvVar:         "http://vault.example.com",
+				common.VaultAllowObjectSkipVerifyEnvVar: "true",
+			},
 			annotations: map[string]string{
 				common.VaultAddrAnnotationDeprecated:                                 "http://vault.example.com",
 				common.VaultImageAnnotationDeprecated:                                "vault:latest",
@@ -124,6 +128,9 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			name: "Handle deprecated annotations mixed",
+			envVars: map[string]string{
+				common.VaultAddrAllowlistEnvVar: "https://vault.newexample.com",
+			},
 			annotations: map[string]string{
 				common.VaultAddrAnnotationDeprecated:                                 "https://vault.newexample.com",
 				common.VaultImageAnnotation:                                          "vault:1.7.0",
@@ -279,6 +286,105 @@ func TestLoadConfig(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, ttp.configWant, config)
+		})
+	}
+}
+
+func TestLoadConfig_AddressHardening(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		envVars        map[string]string
+		wantErr        bool
+		wantAddr       string
+		wantSkipVerify bool
+	}{
+		{
+			name: "object addr override rejected when not in allowlist",
+			annotations: map[string]string{
+				common.VaultAddrAnnotation: "https://evil.attacker.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "object addr override rejected for IMDS link-local",
+			annotations: map[string]string{
+				common.VaultAddrAnnotation: "http://169.254.169.254/latest/meta-data/",
+			},
+			envVars: map[string]string{
+				common.VaultAddrAllowlistEnvVar: "http://169.254.169.254/latest/meta-data/",
+			},
+			wantErr: true,
+		},
+		{
+			name: "object addr override accepted when allowlisted",
+			annotations: map[string]string{
+				common.VaultAddrAnnotation: "https://vault.prod.svc:8200",
+			},
+			envVars: map[string]string{
+				common.VaultAddrAllowlistEnvVar: "https://vault.prod.svc:8200",
+			},
+			wantErr:  false,
+			wantAddr: "https://vault.prod.svc:8200",
+		},
+		{
+			name:        "operator-configured addr is trusted and never validated",
+			annotations: map[string]string{},
+			envVars: map[string]string{
+				common.VaultAddrEnvVar: "https://10.0.0.5:8200",
+			},
+			wantErr:  false,
+			wantAddr: "https://10.0.0.5:8200",
+		},
+		{
+			name: "object skip-verify ignored by default",
+			annotations: map[string]string{
+				common.VaultAddrAnnotation:       "https://vault.prod.svc:8200",
+				common.VaultSkipVerifyAnnotation: "true",
+			},
+			envVars: map[string]string{
+				common.VaultAddrAllowlistEnvVar: "https://vault.prod.svc:8200",
+			},
+			wantErr:        false,
+			wantAddr:       "https://vault.prod.svc:8200",
+			wantSkipVerify: false,
+		},
+		{
+			name: "object skip-verify honored when operator opts in",
+			annotations: map[string]string{
+				common.VaultAddrAnnotation:       "https://vault.prod.svc:8200",
+				common.VaultSkipVerifyAnnotation: "true",
+			},
+			envVars: map[string]string{
+				common.VaultAddrAllowlistEnvVar:         "https://vault.prod.svc:8200",
+				common.VaultAllowObjectSkipVerifyEnvVar: "true",
+			},
+			wantErr:        false,
+			wantAddr:       "https://vault.prod.svc:8200",
+			wantSkipVerify: true,
+		},
+	}
+
+	for _, tt := range tests {
+		ttp := tt
+		t.Run(ttp.name, func(t *testing.T) {
+			for key, value := range ttp.envVars {
+				viper.Set(key, value)
+			}
+			t.Cleanup(func() {
+				viper.Reset()
+				os.Clearenv()
+			})
+
+			config, err := loadConfig(&metav1.ObjectMeta{Annotations: ttp.annotations})
+			if ttp.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, ttp.wantAddr, config.Addr)
+			assert.Equal(t, ttp.wantSkipVerify, config.SkipVerify)
 		})
 	}
 }


### PR DESCRIPTION
## What

Hardens how the webhook treats the `vault-addr` / `bao-addr`, `*-skip-verify`, and related values that come from **admitted object annotations** (untrusted input). Previously an object-supplied address was used verbatim to open an outbound connection during admission and to mint/send a ServiceAccount token — an SSRF + token-exfiltration vector.

## How

- **`pkg/common`** — new pure, table-tested helpers:
  - `ValidateObjectAddr(addr, AddrPolicy)`: http(s) only; operator **allowlist (default-deny)**; SSRF guard blocking loopback / link-local / IMDS / private / CGNAT IP literals (incl. octal/decimal/hex) and metadata hostnames; rejects credentials/query/fragment. Metadata hosts blocked even with `AllowPrivate`.
  - `ResolveObjectSkipVerify(...)`: object `skip-verify` honored only when the operator opts in.
- **`vault` / `bao` config** — an address taken from an annotation is validated against the policy before any client is created; the operator-configured `VAULT_ADDR`/`BAO_ADDR` (env) stays trusted and is an implicit allowlist member. `skip-verify` annotation gated behind the opt-in env var.
- **chart** — documents the new `*_ADDR_ALLOWLIST`, `*_ALLOW_OBJECT_SKIP_VERIFY`, `*_ALLOW_PRIVATE_ADDR` env vars.

Secure-by-default: with no allowlist configured, object-level address overrides are denied; `skip-verify` and private-IP overrides are opt-in. Operator env config is unaffected.

## Test plan

- [x] `go test ./pkg/...` (new: `ValidateObjectAddr` 23-case table, `ResolveObjectSkipVerify`/`SplitAndTrim`, vault & bao `TestLoadConfig_AddressHardening`)
- [x] `go test -race ./pkg/...`
- [x] `go vet ./...`, `gofmt` clean
- [x] existing config tables updated for the secure-by-default behavior and still green